### PR TITLE
[main] fix: fontの指定をコメントアウト

### DIFF
--- a/flutter_main/lib/views/1_root/main_root.dart
+++ b/flutter_main/lib/views/1_root/main_root.dart
@@ -16,8 +16,9 @@ class MainRoot extends StatelessWidget {
           ),
           // 2022.02.28現在、Linuxデスクトップでは絵文字が豆腐になるので試しにフォントを
           // 指定してみたが、Androidのエミュレータだと表示されているので、環境依存っぽい。
-          // とりあえず可愛いので、モチベーションを鑑みて、戻さず行くことにした。
-          fontFamily: 'azuki'),
+          // フォントは組み込みは可能でも、再頒布禁止のものが多く、githubに上げる場合は気をつけること。
+          // fontFamily: 'hoge'
+      ),
       localizationsDelegates: const [
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,

--- a/flutter_main/lib/views/1_root/main_root.dart
+++ b/flutter_main/lib/views/1_root/main_root.dart
@@ -10,14 +10,14 @@ class MainRoot extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-          appBarTheme: const AppBarTheme(
-            backgroundColor: Colors.red,
-            foregroundColor: Colors.white,
-          ),
-          // 2022.02.28現在、Linuxデスクトップでは絵文字が豆腐になるので試しにフォントを
-          // 指定してみたが、Androidのエミュレータだと表示されているので、環境依存っぽい。
-          // フォントは組み込みは可能でも、再頒布禁止のものが多く、githubに上げる場合は気をつけること。
-          // fontFamily: 'hoge'
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Colors.red,
+          foregroundColor: Colors.white,
+        ),
+        // 2022.02.28現在、Linuxデスクトップでは絵文字が豆腐になるので試しにフォントを
+        // 指定してみたが、Androidのエミュレータだと表示されているので、環境依存っぽい。
+        // フォントは組み込みは可能でも、再頒布禁止のものが多く、githubに上げる場合は気をつけること。
+        // fontFamily: 'hoge'
       ),
       localizationsDelegates: const [
         GlobalMaterialLocalizations.delegate,

--- a/flutter_main/pubspec.yaml
+++ b/flutter_main/pubspec.yaml
@@ -36,10 +36,8 @@ flutter:
     # Add assets from the images directory to the application.
     - assets/images/
 
-  fonts:
-    - family: azuki
-      fonts:
-        - asset: fonts/azuki.ttf
-    # - family: Noto
+  # ttf or otf only
+  # fonts:
+    # - family: hoge
     #   fonts:
-    #     - asset: fonts/NotoSans-Regular.ttf
+    #     - asset: fonts/hoge.ttf


### PR DESCRIPTION
azukiフォントは組み込みは可能だったが、再頒布禁止で、githubに上げると抵触していると思われるため削除する。