### PR TITLE
[main] feature: 画面遷移のサンプルを追加する対応

### DIFF
--- a/flutter_main/lib/main.dart
+++ b/flutter_main/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter_main/views/1_root/main_root.dart';
 import 'package:flutter_main/src/3_infrastructures/flutter/story/usecase_mock.dart'
     as usecase_mock;
 import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:url_strategy/url_strategy.dart';
 
 void main() async {
   // ignore: todo レンダリング側のエラーを補足するかどうか？検討する。
@@ -16,6 +17,9 @@ void main() async {
   // if (kReleaseMode) {
   //   ErrorWidget.builder = (FlutterErrorDetails details) => SomethingWrong();
   // }
+
+  // webで起動した場合に、/#/hogeというパスが、/hogeとシンプルになる。
+  setPathUrlStrategy();
 
   // ignore: todo 最終的には使っている環境編数をクラス化して表現して、
   // 起動時に表示するのと、内部を見ないと何を使っているのか？わからない状況を改善したい。

--- a/flutter_main/lib/views/1_root/main_root.dart
+++ b/flutter_main/lib/views/1_root/main_root.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_main/views/2_page/aa_page.dart';
+import 'package:flutter_main/views/2_page/bb_page.dart';
 import 'package:flutter_main/views/2_page/user_page.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
@@ -40,6 +41,11 @@ class MainRoot extends StatelessWidget {
       // ),
       // home: const UserPage(title: 'Flutter Demo Home Page'),
       home: const AaPage(title: 'サンプルAページ!!'),
+      routes: <String, WidgetBuilder> {
+        '/a': (BuildContext context) => const AaPage(title: 'page A'),
+        '/b': (BuildContext context) => const BbPage(title: 'page B'),
+        '/user/info': (BuildContext context) => const UserPage(title: 'page user info'),
+      },
     );
   }
 }

--- a/flutter_main/lib/views/1_root/main_root.dart
+++ b/flutter_main/lib/views/1_root/main_root.dart
@@ -10,32 +10,37 @@ class MainRoot extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        appBarTheme: const AppBarTheme(
-          backgroundColor: Colors.red,
-          foregroundColor: Colors.white,
-        ),
-        // 2022.02.28現在、Linuxデスクトップでは絵文字が豆腐になるので試しにフォントを
-        // 指定してみたが、Androidのエミュレータだと表示されているので、環境依存っぽい。
-        // フォントは組み込みは可能でも、再頒布禁止のものが多く、githubに上げる場合は気をつけること。
-        // fontFamily: 'hoge'
-      ),
-      localizationsDelegates: const [
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: const [
-        Locale('ja', ''),
-      ],
-      home: const MainPage(title: 'サンプルページへのリンクページ'),
-      routes: <String, WidgetBuilder> {
-        '/a': (BuildContext context) => const AaPage(title: 'A画面'),
-        '/b': (BuildContext context) => const BbPage(title: 'B画面'),
-        '/user/info': (BuildContext context) => const UserPage(title: 'ユーザ画面'),
-      },
-    );
+    return createMaterialApp(context, const MainPage());
   }
+}
+
+// テキストボタンを作成する
+MaterialApp createMaterialApp(BuildContext context, Widget mainWidget) {
+  return MaterialApp(
+    title: 'Flutter Demo',
+    theme: ThemeData(
+      appBarTheme: const AppBarTheme(
+        backgroundColor: Colors.red,
+        foregroundColor: Colors.white,
+      ),
+      // 2022.02.28現在、Linuxデスクトップでは絵文字が豆腐になるので試しにフォントを
+      // 指定してみたが、Androidのエミュレータだと表示されているので、環境依存っぽい。
+      // フォントは組み込みは可能でも、再頒布禁止のものが多く、githubに上げる場合は気をつけること。
+      // fontFamily: 'hoge'
+    ),
+    localizationsDelegates: const [
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: const [
+      Locale('ja', ''),
+    ],
+    home: mainWidget,
+    routes: <String, WidgetBuilder>{
+      '/a': (BuildContext context) => const AaPage(),
+      '/b': (BuildContext context) => const BbPage(),
+      '/user/info': (BuildContext context) => const UserPage(),
+    },
+  );
 }

--- a/flutter_main/lib/views/1_root/main_root.dart
+++ b/flutter_main/lib/views/1_root/main_root.dart
@@ -14,8 +14,8 @@ class MainRoot extends StatelessWidget {
   }
 }
 
-// テキストボタンを作成する
-MaterialApp createMaterialApp(BuildContext context, Widget mainWidget) {
+// テスト側でもMaterialAppを作成したいので、メソッド分割している
+MaterialApp createMaterialApp(BuildContext context, Widget homeWidget) {
   return MaterialApp(
     title: 'Flutter Demo',
     theme: ThemeData(
@@ -36,7 +36,7 @@ MaterialApp createMaterialApp(BuildContext context, Widget mainWidget) {
     supportedLocales: const [
       Locale('ja', ''),
     ],
-    home: mainWidget,
+    home: homeWidget,
     routes: <String, WidgetBuilder>{
       '/a': (BuildContext context) => const AaPage(),
       '/b': (BuildContext context) => const BbPage(),

--- a/flutter_main/lib/views/1_root/main_root.dart
+++ b/flutter_main/lib/views/1_root/main_root.dart
@@ -28,6 +28,13 @@ class MainRoot extends StatelessWidget {
       supportedLocales: const [
         Locale('ja', ''),
       ],
+      // initialRoute: "fakeSplash",
+      // onGenerateRoute: (RouteSettings setting) {
+      //   if (setting.name == "fakeSplash")
+      //     return FakeSplashRoute();
+      //   else
+      //     return RealRout(setting);
+      // },
       // theme: ThemeData(
       //   primarySwatch: Colors.red,
       // ),

--- a/flutter_main/lib/views/1_root/main_root.dart
+++ b/flutter_main/lib/views/1_root/main_root.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_main/views/2_page/aa_page.dart';
 import 'package:flutter_main/views/2_page/user_page.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
@@ -30,7 +31,8 @@ class MainRoot extends StatelessWidget {
       // theme: ThemeData(
       //   primarySwatch: Colors.red,
       // ),
-      home: const UserPage(title: 'Flutter Demo Home Page'),
+      // home: const UserPage(title: 'Flutter Demo Home Page'),
+      home: const AaPage(title: 'サンプルAページ!!'),
     );
   }
 }

--- a/flutter_main/lib/views/1_root/main_root.dart
+++ b/flutter_main/lib/views/1_root/main_root.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_main/views/2_page/aa_page.dart';
+import 'package:flutter_main/views/2_page/main_page.dart';
 import 'package:flutter_main/views/2_page/bb_page.dart';
 import 'package:flutter_main/views/2_page/user_page.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -29,22 +30,11 @@ class MainRoot extends StatelessWidget {
       supportedLocales: const [
         Locale('ja', ''),
       ],
-      // initialRoute: "fakeSplash",
-      // onGenerateRoute: (RouteSettings setting) {
-      //   if (setting.name == "fakeSplash")
-      //     return FakeSplashRoute();
-      //   else
-      //     return RealRout(setting);
-      // },
-      // theme: ThemeData(
-      //   primarySwatch: Colors.red,
-      // ),
-      // home: const UserPage(title: 'Flutter Demo Home Page'),
-      home: const AaPage(title: 'サンプルAページ!!'),
+      home: const MainPage(title: 'サンプルページへのリンクページ'),
       routes: <String, WidgetBuilder> {
-        '/a': (BuildContext context) => const AaPage(title: 'page A'),
-        '/b': (BuildContext context) => const BbPage(title: 'page B'),
-        '/user/info': (BuildContext context) => const UserPage(title: 'page user info'),
+        '/a': (BuildContext context) => const AaPage(title: 'A画面'),
+        '/b': (BuildContext context) => const BbPage(title: 'B画面'),
+        '/user/info': (BuildContext context) => const UserPage(title: 'ユーザ画面'),
       },
     );
   }

--- a/flutter_main/lib/views/2_page/aa_page.dart
+++ b/flutter_main/lib/views/2_page/aa_page.dart
@@ -24,7 +24,7 @@ class AaPageState extends State<AaPage> {
             OutlinedButton(
               onPressed: () {
                 setState(() {
-                  str = 'ボタンが押されました。';
+                  str = 'ボタンが押されました🌠🌠🌠';
                 });
                 debugPrint('ボタン1 clicked');
               },

--- a/flutter_main/lib/views/2_page/aa_page.dart
+++ b/flutter_main/lib/views/2_page/aa_page.dart
@@ -38,7 +38,7 @@ class AaPageState extends State<AaPage> {
                 onPressed: () {
                   Navigator.pushNamed(context, '/b');
                 },
-                child: const Text('次の画面へ')),
+                child: const Text('B画面へ')),
           ],
         ),
       ),

--- a/flutter_main/lib/views/2_page/aa_page.dart
+++ b/flutter_main/lib/views/2_page/aa_page.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 
 class AaPage extends StatefulWidget {
-  const AaPage({Key? key, required this.title}) : super(key: key);
-  final String title;
+  const AaPage({Key? key}) : super(key: key);
   @override
   State<AaPage> createState() => AaPageState();
 }
@@ -13,7 +12,7 @@ class AaPageState extends State<AaPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.title),
+        title: const Text('A画面'),
       ),
       body: Center(
         child: Column(

--- a/flutter_main/lib/views/2_page/aa_page.dart
+++ b/flutter_main/lib/views/2_page/aa_page.dart
@@ -37,7 +37,7 @@ class AaPageState extends State<AaPage> {
                   primary: Colors.green,
                 ),
                 onPressed: () {
-                  debugPrint('ボタン2 clicked');
+                  Navigator.pushNamed(context, '/b');
                 },
                 child: const Text('次の画面へ')),
           ],

--- a/flutter_main/lib/views/2_page/aa_page.dart
+++ b/flutter_main/lib/views/2_page/aa_page.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+class AaPage extends StatefulWidget {
+  const AaPage({Key? key, required this.title}) : super(key: key);
+  final String title;
+  @override
+  State<AaPage> createState() => AaPageState();
+}
+
+class AaPageState extends State<AaPage> {
+  String str = "ボタンを押してください。";
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Text(str),
+            const SizedBox(height: 30),
+            OutlinedButton(
+              onPressed: () {
+                setState(() {
+                  str = 'ボタンが押されました。';
+                });
+                debugPrint('ボタン1 clicked');
+              },
+              child: const Text('ボタン1'),
+            ),
+            const SizedBox(height: 30),
+            TextButton(
+                style: TextButton.styleFrom(
+                  // textStyle: const TextStyle(fontSize: 20),
+                  primary: Colors.green,
+                ),
+                onPressed: () {
+                  debugPrint('ボタン2 clicked');
+                },
+                child: const Text('次の画面へ')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_main/lib/views/2_page/bb_page.dart
+++ b/flutter_main/lib/views/2_page/bb_page.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class BbPage extends StatelessWidget {
+  const BbPage({Key? key, required this.title}) : super(key: key);
+  final String title;
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title),
+      ),
+      body: Center(
+        child: Column(
+          // mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text('サンプルBページ!!'),
+            OutlinedButton(
+              onPressed: () {
+                debugPrint('ボタン1 clicked');
+              },
+              child: const Text('ボタン1'),
+            ),
+            const SizedBox(height: 30),
+            TextButton(
+                style: TextButton.styleFrom(
+                  textStyle: const TextStyle(fontSize: 20),
+                  primary: Colors.green,
+                ),
+                onPressed: () {
+                  debugPrint('ボタン2 clicked');
+                },
+                child: const Text('ボタン2')),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(onPressed: () {}),
+    );
+  }
+}

--- a/flutter_main/lib/views/2_page/bb_page.dart
+++ b/flutter_main/lib/views/2_page/bb_page.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 
 class BbPage extends StatelessWidget {
-  const BbPage({Key? key, required this.title}) : super(key: key);
-  final String title;
+  const BbPage({Key? key}) : super(key: key);
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(title),
+        title: const Text('B画面'),
       ),
       body: Center(
         child: Column(

--- a/flutter_main/lib/views/2_page/bb_page.dart
+++ b/flutter_main/lib/views/2_page/bb_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_main/views/4_component/text_button.dart';
 
 class BbPage extends StatelessWidget {
   const BbPage({Key? key}) : super(key: key);
@@ -11,8 +12,10 @@ class BbPage extends StatelessWidget {
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
-          children: const <Widget>[
-            Text('Bページ!!'),
+          children: <Widget>[
+            const Text('Bページ!!'),
+            const SizedBox(height: 30),
+            createTextButton(context, '/', 'トップへ'),
           ],
         ),
       ),

--- a/flutter_main/lib/views/2_page/bb_page.dart
+++ b/flutter_main/lib/views/2_page/bb_page.dart
@@ -11,29 +11,12 @@ class BbPage extends StatelessWidget {
       ),
       body: Center(
         child: Column(
-          // mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('サンプルBページ!!'),
-            OutlinedButton(
-              onPressed: () {
-                debugPrint('ボタン1 clicked');
-              },
-              child: const Text('ボタン1'),
-            ),
-            const SizedBox(height: 30),
-            TextButton(
-                style: TextButton.styleFrom(
-                  textStyle: const TextStyle(fontSize: 20),
-                  primary: Colors.green,
-                ),
-                onPressed: () {
-                  debugPrint('ボタン2 clicked');
-                },
-                child: const Text('ボタン2')),
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: const <Widget>[
+            Text('Bページ!!'),
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(onPressed: () {}),
     );
   }
 }

--- a/flutter_main/lib/views/2_page/main_page.dart
+++ b/flutter_main/lib/views/2_page/main_page.dart
@@ -2,13 +2,12 @@ import 'package:flutter/material.dart';
 
 // メインページ　主に各ページのリンクを置いておくだけ。
 class MainPage extends StatelessWidget {
-  const MainPage({Key? key, required this.title}) : super(key: key);
-  final String title;
+  const MainPage({Key? key}) : super(key: key);
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(title),
+        title: const Text('サンプルページへのリンクページ'),
       ),
       body: Center(
         child: Column(
@@ -29,13 +28,13 @@ class MainPage extends StatelessWidget {
 // テキストボタンを作成する
 TextButton createTextButton(BuildContext context, String path, String txt) {
   return TextButton(
-      style: TextButton.styleFrom(
-        textStyle: const TextStyle(fontSize: 20),
-        primary: Colors.green,
-      ),
-      onPressed: () {
-        Navigator.pushNamed(context, path);
-      },
-      child: Text(txt),
+    style: TextButton.styleFrom(
+      textStyle: const TextStyle(fontSize: 20),
+      primary: Colors.green,
+    ),
+    onPressed: () {
+      Navigator.pushNamed(context, path);
+    },
+    child: Text(txt),
   );
 }

--- a/flutter_main/lib/views/2_page/main_page.dart
+++ b/flutter_main/lib/views/2_page/main_page.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class MainPage extends StatelessWidget {
+  const MainPage({Key? key, required this.title}) : super(key: key);
+  final String title;
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(title),
+      ),
+      body: Center(
+        child: Column(
+          // mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const SizedBox(height: 30),
+            createTextButton(context, '/a', 'a画面へ'),
+            const SizedBox(height: 30),
+            createTextButton(context, '/b', 'b画面へ'),
+            const SizedBox(height: 30),
+            createTextButton(context, '/user/info', 'ユーザ画面へ'),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// テキストボタンの作成をする
+TextButton createTextButton(BuildContext context, String path, String txt) {
+  return TextButton(
+      style: TextButton.styleFrom(
+        textStyle: const TextStyle(fontSize: 20),
+        primary: Colors.green,
+      ),
+      onPressed: () {
+        Navigator.pushNamed(context, path);
+      },
+      child: Text(txt),
+  );
+}

--- a/flutter_main/lib/views/2_page/main_page.dart
+++ b/flutter_main/lib/views/2_page/main_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_main/views/4_component/text_button.dart';
 
 // メインページ　主に各ページのリンクを置いておくだけ。
 class MainPage extends StatelessWidget {
@@ -23,18 +24,4 @@ class MainPage extends StatelessWidget {
       ),
     );
   }
-}
-
-// テキストボタンを作成する
-TextButton createTextButton(BuildContext context, String path, String txt) {
-  return TextButton(
-    style: TextButton.styleFrom(
-      textStyle: const TextStyle(fontSize: 20),
-      primary: Colors.green,
-    ),
-    onPressed: () {
-      Navigator.pushNamed(context, path);
-    },
-    child: Text(txt),
-  );
 }

--- a/flutter_main/lib/views/2_page/main_page.dart
+++ b/flutter_main/lib/views/2_page/main_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+// メインページ　主に各ページのリンクを置いておくだけ。
 class MainPage extends StatelessWidget {
   const MainPage({Key? key, required this.title}) : super(key: key);
   final String title;
@@ -11,9 +12,8 @@ class MainPage extends StatelessWidget {
       ),
       body: Center(
         child: Column(
-          // mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            const SizedBox(height: 30),
             createTextButton(context, '/a', 'a画面へ'),
             const SizedBox(height: 30),
             createTextButton(context, '/b', 'b画面へ'),
@@ -26,7 +26,7 @@ class MainPage extends StatelessWidget {
   }
 }
 
-// テキストボタンの作成をする
+// テキストボタンを作成する
 TextButton createTextButton(BuildContext context, String path, String txt) {
   return TextButton(
       style: TextButton.styleFrom(

--- a/flutter_main/lib/views/2_page/user_page.dart
+++ b/flutter_main/lib/views/2_page/user_page.dart
@@ -3,8 +3,7 @@ import 'package:flutter_main/src/1_usecases/user_usecase.dart' as user_usecase;
 import 'package:flutter_main/views/3_template/wrap_template.dart' as wrap;
 
 class UserPage extends StatefulWidget {
-  const UserPage({Key? key, required this.title}) : super(key: key);
-  final String title;
+  const UserPage({Key? key}) : super(key: key);
   @override
   State<UserPage> createState() => UserPageState();
 }
@@ -39,7 +38,7 @@ class UserPageState extends State<UserPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.title),
+        title: const Text('ユーザ画面'),
       ),
       body: Center(
         child: Column(

--- a/flutter_main/lib/views/4_component/text_button.dart
+++ b/flutter_main/lib/views/4_component/text_button.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+// テキストボタンを作成する（htmlで言う所のaタグとなる。）
+TextButton createTextButton(BuildContext context, String path, String txt) {
+  return TextButton(
+    style: TextButton.styleFrom(
+      textStyle: const TextStyle(fontSize: 20),
+      primary: Colors.green,
+    ),
+    onPressed: () {
+      Navigator.pushNamed(context, path);
+    },
+    child: Text(txt),
+  );
+}

--- a/flutter_main/pubspec.yaml
+++ b/flutter_main/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   http: ^0.13.4
+  url_strategy: ^0.2.0
 
 dev_dependencies:
   flutter_test:

--- a/flutter_main/test/integration_test/views/2_page/user_page_test.dart
+++ b/flutter_main/test/integration_test/views/2_page/user_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_main/views/1_root/main_root.dart';
+import 'package:flutter_main/views/2_page/user_page.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:integration_test/integration_test.dart';
@@ -14,14 +15,21 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('ユーザ情報表示テスト', () {
+    setUp(() {});
     testWidgets('初回は空文字で表示すること', (WidgetTester tester) async {
-      await tester.pumpWidget(const MainRoot());
+      await tester.pumpWidget(Builder(builder: (BuildContext context) {
+        return createMaterialApp(context, const UserPage());
+      }));
+
       expect(find.text(''), findsOneWidget);
       expect(find.text('{"name":"hello"}'), findsNothing);
     });
     testWidgets('ボタンを押したら、アラートが表示されて、アラートの文字そのままボタンを押すと、json文字列が表示されていること',
         (WidgetTester tester) async {
-      await tester.pumpWidget(const MainRoot());
+      await tester.pumpWidget(Builder(builder: (BuildContext context) {
+        return createMaterialApp(context, const UserPage());
+      }));
+
       await tester.tap(find.byIcon(Icons.add));
       await tester.pumpAndSettle();
 


### PR DESCRIPTION
* トップページを各ページへのリンク置いたページに変更
* 移動先として、A画面とB画面を追加
* テキストリンクを作成する処理が、そのままだと記述が多いのでcomponent化
* Webで開くとURLが/#/が付いてしまうのを外すプラグインを追加
* integrationテスト側で対象のページが開けるように記述を修正
