### PR TITLE
[main] feature: ホーム画面とデザイン一覧画面を追加

### DIFF
--- a/flutter_main/lib/views/1_root/main_root.dart
+++ b/flutter_main/lib/views/1_root/main_root.dart
@@ -3,6 +3,7 @@ import 'package:flutter_main/views/2_page/aa_page.dart';
 import 'package:flutter_main/views/2_page/main_page.dart';
 import 'package:flutter_main/views/2_page/bb_page.dart';
 import 'package:flutter_main/views/2_page/user_page.dart';
+import 'package:flutter_main/views/2_page/home_page.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 class MainRoot extends StatelessWidget {
@@ -41,6 +42,7 @@ MaterialApp createMaterialApp(BuildContext context, Widget homeWidget) {
       '/a': (BuildContext context) => const AaPage(),
       '/b': (BuildContext context) => const BbPage(),
       '/user/info': (BuildContext context) => const UserPage(),
+      '/user/home': (BuildContext context) => const HomePage(),
     },
   );
 }

--- a/flutter_main/lib/views/1_root/main_root.dart
+++ b/flutter_main/lib/views/1_root/main_root.dart
@@ -4,6 +4,7 @@ import 'package:flutter_main/views/2_page/main_page.dart';
 import 'package:flutter_main/views/2_page/bb_page.dart';
 import 'package:flutter_main/views/2_page/user_page.dart';
 import 'package:flutter_main/views/2_page/home_page.dart';
+import 'package:flutter_main/views/2_page/design_page.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 class MainRoot extends StatelessWidget {
@@ -43,6 +44,7 @@ MaterialApp createMaterialApp(BuildContext context, Widget homeWidget) {
       '/b': (BuildContext context) => const BbPage(),
       '/user/info': (BuildContext context) => const UserPage(),
       '/user/home': (BuildContext context) => const HomePage(),
+      '/designs': (BuildContext context) => const DesignPage()
     },
   );
 }

--- a/flutter_main/lib/views/2_page/design_page.dart
+++ b/flutter_main/lib/views/2_page/design_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter_main/views/4_component/text_button.dart';
 import 'package:flutter_main/views/4_component/design_catalog_component.dart';
 import 'package:flutter_main/views/3_template/custum_colors.dart';
 
-//ホーム画面
 class DesignPage extends StatefulWidget {
   const DesignPage({Key? key}) : super(key: key);
   @override

--- a/flutter_main/lib/views/2_page/design_page.dart
+++ b/flutter_main/lib/views/2_page/design_page.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_main/views/4_component/text_button.dart';
+import 'package:flutter_main/views/4_component/design_catalog_component.dart';
+import 'package:flutter_main/views/3_template/custum_colors.dart';
+
+//ホーム画面
+class DesignPage extends StatefulWidget {
+  const DesignPage({Key? key}) : super(key: key);
+  @override
+  State<DesignPage> createState() => DesignPageState();
+}
+
+class DesignPageState extends State<DesignPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('デザイン一覧画面'),
+      ),
+      body: Center(
+          child: Column(
+        children: [
+          createCatalogBlock(
+              title: "色一覧",
+              children: [
+                createColorBlock(
+                    title: "grayHeavy",
+                    color: CustumColors.grayHeavy,
+                    props: "CustumColors.grayHeavy"),
+                createColorBlock(
+                    title: "gray",
+                    color: CustumColors.gray,
+                    props: "CustumColors.gray"),
+                createColorBlock(
+                    title: "grayIcon",
+                    color: CustumColors.grayIcon,
+                    props: "CustumColors.grayIcon"),
+                createColorBlock(
+                    title: "grayLight",
+                    color: CustumColors.grayLight,
+                    props: "CustumColors.grayLight"),
+              ],
+              importPath:
+                  "import 'package:flutter_main/views/3_template/custum_colors.dart'"),
+          createCatalogBlock(
+              children: [
+                createTextButton(context, "/designs", "createTextButton"),
+                createActionButton(
+                    txt: "createActionButton", onPressed: () => {})
+              ],
+              title: "ボタン",
+              importPath:
+                  "import 'package:flutter_main/views/4_component/text_button.dart'")
+        ],
+      )),
+    );
+  }
+}

--- a/flutter_main/lib/views/2_page/home_page.dart
+++ b/flutter_main/lib/views/2_page/home_page.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_main/views/4_component/text_button.dart';
+import 'package:flutter_main/views/4_component/bottom_navigation_bar_layout.dart';
+import 'package:flutter_main/views/3_template/custum_colors.dart';
 
 //ホーム画面
 class HomePage extends StatefulWidget {
@@ -11,84 +14,74 @@ class HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Center(
-          child: Column(
-        children: [
-          Column(mainAxisAlignment: MainAxisAlignment.center, children: [
-            Column(children: [
-              const Icon(
-                Icons.abc,
-                size: 220,
-              ),
-              Container(
-                  child: const Text("管理アプリ"),
-                  margin: const EdgeInsets.only(top: 24, bottom: 9)),
-              Container(
-                  child: const Text("0.5.0(1234)",
-                      style:
-                          TextStyle(color: Color.fromARGB(255, 163, 163, 164))),
-                  margin: const EdgeInsets.only(top: 9, bottom: 42)),
-              Container(
-                margin: const EdgeInsets.only(bottom: 42),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: const [
-                    Icon(
-                      Icons.help_outline,
-                      color: Color.fromARGB(255, 138, 138, 138),
-                    ),
-                    Text("ヘルプページはこちら",
-                        style: TextStyle(
-                            color: Color.fromARGB(
-                          255,
-                          104,
-                          104,
-                          105,
-                        )))
-                  ],
+        body: Center(
+            child: Column(
+          children: [
+            Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+              Column(children: [
+                const Icon(
+                  Icons.abc,
+                  size: 220,
                 ),
-              ),
-              Container(
-                  child: const Text("ライセンス情報",
-                      style:
-                          TextStyle(color: Color.fromARGB(255, 104, 104, 105))),
-                  margin: const EdgeInsets.only(
-                    top: 20,
-                  ))
+                Container(
+                    child: const Text("管理アプリ"),
+                    margin: const EdgeInsets.only(top: 24, bottom: 9)),
+                Container(
+                    child: const Text("0.5.0(1234)",
+                        style: TextStyle(color: CustumColors.grayLight)),
+                    margin: const EdgeInsets.only(top: 9, bottom: 42)),
+                Container(
+                  margin: const EdgeInsets.only(bottom: 42),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: const [
+                      Icon(
+                        Icons.help_outline,
+                        color: CustumColors.grayIcon,
+                      ),
+                      Text("ヘルプページはこちら",
+                          style: TextStyle(color: CustumColors.gray))
+                    ],
+                  ),
+                ),
+                Container(
+                    child: const Text("ライセンス情報",
+                        style: TextStyle(color: CustumColors.gray)),
+                    margin: const EdgeInsets.only(
+                      top: 20,
+                    ))
+              ]),
             ]),
-          ]),
+            Container(
+                margin: const EdgeInsets.only(left: 20, right: 20),
+                child: const Text.rich(TextSpan(
+                    style: TextStyle(color: CustumColors.grayHeavy),
+                    children: [
+                      TextSpan(
+                          text: "利用規約",
+                          style:
+                              TextStyle(decoration: TextDecoration.underline)),
+                      TextSpan(
+                        text: "と",
+                      ),
+                      TextSpan(
+                          text: "プライバシーポリシー",
+                          style:
+                              TextStyle(decoration: TextDecoration.underline)),
+                      TextSpan(text: "に同意の上、二次元バーコードの読み込みを開始してください。"),
+                    ])))
+          ],
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        )),
+        bottomNavigationBar: createBottomLayout(children: [
           Container(
-              margin: const EdgeInsets.only(left: 20, right: 20),
-              child: const Text.rich(TextSpan(
-                  style: TextStyle(color: Color.fromARGB(255, 85, 85, 85)),
-                  children: [
-                    TextSpan(
-                        text: "利用規約",
-                        style: TextStyle(decoration: TextDecoration.underline)),
-                    TextSpan(
-                      text: "と",
-                    ),
-                    TextSpan(
-                        text: "プライバシーポリシー",
-                        style: TextStyle(decoration: TextDecoration.underline)),
-                    TextSpan(text: "に同意の上、二次元バーコードの読み込みを開始してください。")
-                  ])))
-        ],
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      )),
-      bottomNavigationBar: Container(
-        decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(4),
-            color: const Color.fromARGB(255, 104, 104, 105)),
-        margin: const EdgeInsets.only(left: 20, right: 20, bottom: 24),
-        height: 50,
-        child: TextButton(
-            onPressed: (() => {}),
-            child: const Text(
-              "二次元バーコードを読み込む",
-              style: TextStyle(color: Colors.white),
-            )),
-      ),
-    );
+              margin: const EdgeInsets.only(bottom: 16),
+              child: SizedBox(
+                child: createActionButton(
+                    txt: "二次元バーコードを読み込む", onPressed: () => {}),
+                height: 50,
+                width: double.infinity,
+              )),
+        ]));
   }
 }

--- a/flutter_main/lib/views/2_page/home_page.dart
+++ b/flutter_main/lib/views/2_page/home_page.dart
@@ -79,7 +79,7 @@ class HomePageState extends State<HomePage> {
       bottomNavigationBar: Container(
         decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(4),
-            color: Color(int.parse("FF" "686869", radix: 16))),
+            color: const Color.fromARGB(255, 104, 104, 105)),
         margin: const EdgeInsets.only(left: 20, right: 20, bottom: 24),
         height: 50,
         child: TextButton(

--- a/flutter_main/lib/views/2_page/home_page.dart
+++ b/flutter_main/lib/views/2_page/home_page.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+//ホーム画面
+class HomePage extends StatefulWidget {
+  const HomePage({Key? key}) : super(key: key);
+  @override
+  State<HomePage> createState() => HomePageState();
+}
+
+class HomePageState extends State<HomePage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+          child: Column(
+        children: [
+          Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+            Column(children: [
+              const Icon(
+                Icons.abc,
+                size: 220,
+              ),
+              Container(
+                  child: const Text("管理アプリ"),
+                  margin: const EdgeInsets.only(top: 24, bottom: 9)),
+              Container(
+                  child: const Text("0.5.0(1234)",
+                      style:
+                          TextStyle(color: Color.fromARGB(255, 163, 163, 164))),
+                  margin: const EdgeInsets.only(top: 9, bottom: 42)),
+              Container(
+                margin: const EdgeInsets.only(bottom: 42),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: const [
+                    Icon(
+                      Icons.help_outline,
+                      color: Color.fromARGB(255, 138, 138, 138),
+                    ),
+                    Text("ヘルプページはこちら",
+                        style: TextStyle(
+                            color: Color.fromARGB(
+                          255,
+                          104,
+                          104,
+                          105,
+                        )))
+                  ],
+                ),
+              ),
+              Container(
+                  child: const Text("ライセンス情報",
+                      style:
+                          TextStyle(color: Color.fromARGB(255, 104, 104, 105))),
+                  margin: const EdgeInsets.only(
+                    top: 20,
+                  ))
+            ]),
+          ]),
+          Container(
+              margin: const EdgeInsets.only(left: 20, right: 20),
+              child: const Text.rich(TextSpan(
+                  style: TextStyle(color: Color.fromARGB(255, 85, 85, 85)),
+                  children: [
+                    TextSpan(
+                        text: "利用規約",
+                        style: TextStyle(decoration: TextDecoration.underline)),
+                    TextSpan(
+                      text: "と",
+                    ),
+                    TextSpan(
+                        text: "プライバシーポリシー",
+                        style: TextStyle(decoration: TextDecoration.underline)),
+                    TextSpan(text: "に同意の上、二次元バーコードの読み込みを開始してください。")
+                  ])))
+        ],
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      )),
+      bottomNavigationBar: Container(
+        decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(4),
+            color: Color(int.parse("FF" "686869", radix: 16))),
+        margin: const EdgeInsets.only(left: 20, right: 20, bottom: 24),
+        height: 50,
+        child: TextButton(
+            onPressed: (() => {}),
+            child: const Text(
+              "二次元バーコードを読み込む",
+              style: TextStyle(color: Colors.white),
+            )),
+      ),
+    );
+  }
+}

--- a/flutter_main/lib/views/2_page/home_page.dart
+++ b/flutter_main/lib/views/2_page/home_page.dart
@@ -53,7 +53,7 @@ class HomePageState extends State<HomePage> {
               ]),
             ]),
             Container(
-                margin: const EdgeInsets.only(left: 20, right: 20),
+                margin: const EdgeInsets.only(left: 20, right: 20, bottom: 16),
                 child: const Text.rich(TextSpan(
                     style: TextStyle(color: CustumColors.grayHeavy),
                     children: [

--- a/flutter_main/lib/views/2_page/home_page.dart
+++ b/flutter_main/lib/views/2_page/home_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter_main/views/4_component/text_button.dart';
 import 'package:flutter_main/views/4_component/bottom_navigation_bar_layout.dart';
 import 'package:flutter_main/views/3_template/custum_colors.dart';
 
-//ホーム画面
+// ホーム画面
 class HomePage extends StatefulWidget {
   const HomePage({Key? key}) : super(key: key);
   @override

--- a/flutter_main/lib/views/2_page/main_page.dart
+++ b/flutter_main/lib/views/2_page/main_page.dart
@@ -21,6 +21,8 @@ class MainPage extends StatelessWidget {
             createTextButton(context, '/user/info', 'ユーザ画面へ'),
             const SizedBox(height: 30),
             createTextButton(context, '/user/home', 'ホーム画面へ'),
+            const SizedBox(height: 30),
+            createTextButton(context, '/designs', 'デザイン画面へ'),
           ],
         ),
       ),

--- a/flutter_main/lib/views/2_page/main_page.dart
+++ b/flutter_main/lib/views/2_page/main_page.dart
@@ -19,6 +19,8 @@ class MainPage extends StatelessWidget {
             createTextButton(context, '/b', 'b画面へ'),
             const SizedBox(height: 30),
             createTextButton(context, '/user/info', 'ユーザ画面へ'),
+            const SizedBox(height: 30),
+            createTextButton(context, '/user/home', 'ホーム画面へ'),
           ],
         ),
       ),

--- a/flutter_main/lib/views/3_template/custum_colors.dart
+++ b/flutter_main/lib/views/3_template/custum_colors.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+class CustumColors {
+  //グレー系のカラー(上から濃い順)
+  static const grayHeavy = Color.fromARGB(255, 85, 85, 85);
+  static const gray = Color.fromARGB(255, 104, 104, 105);
+  static const grayIcon = Color.fromARGB(255, 138, 138, 138);
+  static const grayLight = Color.fromARGB(255, 163, 163, 164);
+}

--- a/flutter_main/lib/views/4_component/bottom_navigation_bar_layout.dart
+++ b/flutter_main/lib/views/4_component/bottom_navigation_bar_layout.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+Container createBottomLayout({required List<Widget> children}) {
+  return Container(
+    margin: const EdgeInsets.only(left: 20, right: 20),
+    child: Column(
+      children: children,
+      mainAxisAlignment: MainAxisAlignment.end,
+      mainAxisSize: MainAxisSize.min,
+    ),
+  );
+}

--- a/flutter_main/lib/views/4_component/design_catalog_component.dart
+++ b/flutter_main/lib/views/4_component/design_catalog_component.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../3_template/custum_colors.dart';
+
+Column createCatalogBlock(
+    {required List<Widget> children,
+    required String title,
+    String? importPath}) {
+  return Column(
+    children: [
+      Row(children: [
+        OutlinedButton(
+            onPressed: () =>
+                {Clipboard.setData(ClipboardData(text: importPath))},
+            child: Text(title)),
+      ], mainAxisAlignment: MainAxisAlignment.center),
+      Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: children,
+      )
+    ],
+  );
+}
+
+Column createColorBlock(
+    {required String title, required Color color, String? props}) {
+  return Column(
+    children: [
+      Container(
+        margin: const EdgeInsets.all(10),
+        child: Column(
+          children: [
+            SizedBox(
+              child: ElevatedButton(
+                child: const Text(''),
+                style: ElevatedButton.styleFrom(
+                  primary: color,
+                  shape: const CircleBorder(),
+                ),
+                onPressed: () =>
+                    {Clipboard.setData(ClipboardData(text: props))},
+              ),
+              width: 50,
+              height: 50,
+            ),
+            Text(title)
+          ],
+        ),
+      )
+    ],
+  );
+}

--- a/flutter_main/lib/views/4_component/design_catalog_component.dart
+++ b/flutter_main/lib/views/4_component/design_catalog_component.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import '../3_template/custum_colors.dart';
-
 Column createCatalogBlock(
     {required List<Widget> children,
     required String title,

--- a/flutter_main/lib/views/4_component/design_catalog_component.dart
+++ b/flutter_main/lib/views/4_component/design_catalog_component.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+// カタログを作成する時に使用
 Column createCatalogBlock(
     {required List<Widget> children,
     required String title,
+    // 開発時、importパスをコピーするときに使用
     String? importPath}) {
   return Column(
     children: [
@@ -22,7 +24,10 @@ Column createCatalogBlock(
 }
 
 Column createColorBlock(
-    {required String title, required Color color, String? props}) {
+    {required String title,
+    required Color color,
+    // 開発時、コピペしやすいように使用
+    String? props}) {
   return Column(
     children: [
       Container(

--- a/flutter_main/lib/views/4_component/text_button.dart
+++ b/flutter_main/lib/views/4_component/text_button.dart
@@ -13,3 +13,16 @@ TextButton createTextButton(BuildContext context, String path, String txt) {
     child: Text(txt),
   );
 }
+
+ElevatedButton createActionButton(
+    {void Function()? onPressed, required String txt, bool outlined = false}) {
+  return ElevatedButton(
+    onPressed: onPressed,
+    child: Text(txt),
+    style: ElevatedButton.styleFrom(
+        primary: const Color.fromARGB(255, 104, 104, 105),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(4),
+        )),
+  );
+}

--- a/flutter_main/lib/views/4_component/text_button.dart
+++ b/flutter_main/lib/views/4_component/text_button.dart
@@ -15,7 +15,7 @@ TextButton createTextButton(BuildContext context, String path, String txt) {
 }
 
 ElevatedButton createActionButton(
-    {void Function()? onPressed, required String txt, bool outlined = false}) {
+    {void Function()? onPressed, required String txt}) {
   return ElevatedButton(
     onPressed: onPressed,
     child: Text(txt),


### PR DESCRIPTION
### ホーム画面

flutterでの画面サンプル作成のために作成。

具体的には下記を確認。

- コンポーネントの粒度
- 共通化できる箇所

### デザイン一覧画面

デザイン確認用に作成。

- 新規の人でも、コンポーネントの使用方法をわかりやすく出来る
- デザイナー、エンジニア間のコミュニケーションが円滑に出来る
- よく利用するコードをボタンでコピー出来る

### デザインの工夫余地について

- レイアウト用のコンポーネントなども作成すれば、もっと使いやすくなりそう。
