### PR TITLE
[main] feature: 機器設定画面を追加

### DIFF
--- a/flutter_main/README.md
+++ b/flutter_main/README.md
@@ -1,6 +1,6 @@
 # flutter_main
 
-スクショを取りたいのであれば、公式ドキュメントを参考に、Androidエミュレータのセットアップをすること。
+スクショを取りたいのであれば、公式ドキュメントを参考に、Android エミュレータのセットアップをすること。
 
 ## setup
 
@@ -29,7 +29,7 @@ flutter format integration_test/*
 flutter clean
 ```
 
-## formatとテストをするチェック用スクリプト
+## format とテストをするチェック用スクリプト
 
 ```bash
 ./script/check.sh
@@ -40,3 +40,14 @@ flutter clean
 ```bash
 node http-json-server.js
 ```
+
+## デザイン一覧画面について
+
+### 概要
+
+- 再利用可能なコンポーネントがカタログ形式で見ることが可能
+- コンポーネントの使用方法とその意図を第三者が理解しやすいように作成
+
+### 機能
+
+- コンポーネント名を押すと import path がクリップボードにコピーされる

--- a/flutter_main/lib/views/1_root/main_root.dart
+++ b/flutter_main/lib/views/1_root/main_root.dart
@@ -5,6 +5,7 @@ import 'package:flutter_main/views/2_page/bb_page.dart';
 import 'package:flutter_main/views/2_page/user_page.dart';
 import 'package:flutter_main/views/2_page/home_page.dart';
 import 'package:flutter_main/views/2_page/design_page.dart';
+import 'package:flutter_main/views/2_page/device_setting_page.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 class MainRoot extends StatelessWidget {
@@ -44,7 +45,8 @@ MaterialApp createMaterialApp(BuildContext context, Widget homeWidget) {
       '/b': (BuildContext context) => const BbPage(),
       '/user/info': (BuildContext context) => const UserPage(),
       '/user/home': (BuildContext context) => const HomePage(),
-      '/designs': (BuildContext context) => const DesignPage()
+      '/designs': (BuildContext context) => const DesignPage(),
+      '/device/setting': (BuildContext context) => const DeviceSettingPage()
     },
   );
 }

--- a/flutter_main/lib/views/2_page/design_page.dart
+++ b/flutter_main/lib/views/2_page/design_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_main/views/4_component/text_button.dart';
 import 'package:flutter_main/views/4_component/design_catalog_component.dart';
 import 'package:flutter_main/views/3_template/custum_colors.dart';
+import 'package:flutter_main/views/4_component/stepper_indicator_vertical.dart';
+import 'package:flutter_main/views/4_component/encircled_number.dart';
 
 class DesignPage extends StatefulWidget {
   const DesignPage({Key? key}) : super(key: key);
@@ -13,12 +15,11 @@ class DesignPageState extends State<DesignPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('デザイン一覧画面'),
-      ),
-      body: Center(
-          child: Column(
-        children: [
+        appBar: AppBar(
+          title: const Text('デザイン一覧画面'),
+        ),
+        body: Center(
+            child: Column(children: [
           createCatalogBlock(
               title: "色一覧",
               children: [
@@ -49,9 +50,35 @@ class DesignPageState extends State<DesignPage> {
               ],
               title: "ボタン",
               importPath:
-                  "import 'package:flutter_main/views/4_component/text_button.dart'")
-        ],
-      )),
-    );
+                  "import 'package:flutter_main/views/4_component/text_button.dart'"),
+          createCatalogBlock(
+            title: "ステッパーインジケーター(垂直)",
+            importPath:
+                "'package:flutter_main/views/4_component/stepper_indicator_vertical.dart'",
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: createStepperIndicatorVertical(children: [
+                  const Text("配列の"),
+                  const Text("数に合わせて"),
+                  Column(
+                    children: const [Text("ステップ数が"), Text("変わるよ")],
+                  )
+                ]),
+              )
+            ],
+          ),
+          createCatalogBlock(
+              children: [
+                createEncircledNumber(num: "2"),
+                createEncircledNumber(num: "3"),
+                createEncircledNumber(num: "5"),
+                createEncircledNumber(num: "7"),
+                createEncircledNumber(num: "11")
+              ],
+              title: "丸数字",
+              importPath:
+                  "import 'package:flutter_main/views/4_component/encircled_number.dart';")
+        ])));
   }
 }

--- a/flutter_main/lib/views/2_page/design_page.dart
+++ b/flutter_main/lib/views/2_page/design_page.dart
@@ -20,6 +20,14 @@ class DesignPageState extends State<DesignPage> {
         ),
         body: Center(
             child: Column(children: [
+          Container(
+            margin: const EdgeInsets.all(30),
+            child: const Text("使用方法"),
+          ),
+          Container(
+            margin: const EdgeInsets.all(10),
+            child: const Text("コンポーネント名を押すと、パスがクリップボードにコピーされます."),
+          ),
           createCatalogBlock(
               title: "色一覧",
               children: [

--- a/flutter_main/lib/views/2_page/device_setting_page.dart
+++ b/flutter_main/lib/views/2_page/device_setting_page.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_main/views/4_component/text_button.dart';
+import 'package:flutter_main/views/4_component/bottom_navigation_bar_layout.dart';
+import 'package:flutter_main/views/4_component/stepper_indicator_vertical.dart';
+import 'package:flutter_main/views/3_template/custum_colors.dart';
+
+// 導入前確認画面_共用玄関
+class DeviceSettingPage extends StatefulWidget {
+  const DeviceSettingPage({Key? key}) : super(key: key);
+  @override
+  State<DeviceSettingPage> createState() => DeviceSettingPageState();
+}
+
+class DeviceSettingPageState extends State<DeviceSettingPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: const Text('機器の設定'),
+          backgroundColor: CustumColors.grayHeavy,
+        ),
+        body: Center(
+            child: Column(children: [
+          Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+            Column(children: [
+              Container(
+                  margin: const EdgeInsets.only(top: 32),
+                  child: const Icon(
+                    Icons.abc,
+                    size: 44,
+                  ),
+                  decoration: BoxDecoration(
+                    color: CustumColors.grayBg,
+                    borderRadius: BorderRadius.circular(10),
+                  )),
+              Container(
+                child: const Text("ドエル南麻布/メインエントランス"),
+                margin: const EdgeInsets.only(top: 10),
+              ),
+            ]),
+          ]),
+          Container(
+            margin: const EdgeInsets.only(left: 16, right: 19),
+            width: double.infinity,
+            child: Column(
+              mainAxisSize: MainAxisSize.max,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                    child: const Text(
+                      "利用する機器を設定します",
+                      style: TextStyle(
+                          color: CustumColors.grayHeavy,
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold),
+                    ),
+                    margin: const EdgeInsets.only(top: 24)),
+                Container(
+                    child: const Text(
+                      "下記の順で設定を進めます。作業を途中で中断すると、最初からやり直しになります。完了まで行って下さい。",
+                    ),
+                    margin: const EdgeInsets.only(
+                      top: 20,
+                    ))
+              ],
+            ),
+          ),
+          Container(
+            margin: const EdgeInsets.only(left: 16, right: 19, top: 36),
+            child: Column(
+              children: createStepperIndicatorVertical(children: [
+                const Text("共用玄関用キーパッドの設定"),
+                const Text("解錠テスト"),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: const [
+                    Text("ハブの設定"),
+                    Text("ハブがある場合は必須",
+                        style: TextStyle(
+                            color: CustumColors.grayLight, fontSize: 12))
+                  ],
+                )
+              ]),
+            ),
+          ),
+        ])),
+        bottomNavigationBar: createBottomLayout(children: [
+          Container(
+              margin: const EdgeInsets.only(bottom: 16),
+              child: SizedBox(
+                child: createActionButton(txt: "はじめる", onPressed: () => {}),
+                height: 50,
+                width: double.infinity,
+              )),
+        ]));
+  }
+}

--- a/flutter_main/lib/views/2_page/home_page.dart
+++ b/flutter_main/lib/views/2_page/home_page.dart
@@ -78,7 +78,9 @@ class HomePageState extends State<HomePage> {
               margin: const EdgeInsets.only(bottom: 16),
               child: SizedBox(
                 child: createActionButton(
-                    txt: "二次元バーコードを読み込む", onPressed: () => {}),
+                    txt: "二次元バーコードを読み込む",
+                    onPressed: () =>
+                        {Navigator.pushNamed(context, "/device/setting")}),
                 height: 50,
                 width: double.infinity,
               )),

--- a/flutter_main/lib/views/3_template/custum_colors.dart
+++ b/flutter_main/lib/views/3_template/custum_colors.dart
@@ -6,4 +6,5 @@ class CustumColors {
   static const gray = Color.fromARGB(255, 104, 104, 105);
   static const grayIcon = Color.fromARGB(255, 138, 138, 138);
   static const grayLight = Color.fromARGB(255, 163, 163, 164);
+  static const grayBg = Color.fromARGB(255, 220, 220, 221);
 }

--- a/flutter_main/lib/views/4_component/bottom_navigation_bar_layout.dart
+++ b/flutter_main/lib/views/4_component/bottom_navigation_bar_layout.dart
@@ -1,5 +1,18 @@
 import 'package:flutter/material.dart';
 
+/// ### 概要
+///
+/// - 指定した位置に指定したコンポーネントを配置する
+///
+/// ### 目的
+///
+/// - bottomNavigationBarで垂直にコンポーネントが配置されるように作成
+///
+/// ### 使用例
+///
+/// - ほぼ全画面
+/// - 主に、画面遷移の際のボタンを配置するときに使用
+
 Container createBottomLayout({required List<Widget> children}) {
   return Container(
     margin: const EdgeInsets.only(left: 20, right: 20),

--- a/flutter_main/lib/views/4_component/design_catalog_component.dart
+++ b/flutter_main/lib/views/4_component/design_catalog_component.dart
@@ -1,7 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-// カタログを作成する時に使用
+/// ### 概要
+///
+/// - カタログを作成する時に使用
+///
+/// ### 目的
+///
+/// - デザイン一覧画面でコンポーネントのタイトルを付けやすくするため
+///
+/// ### 利用例
+///
+/// - デザイン一覧画面
+///
+/// ### 備考
+///
+/// - 引数のimportPathには、タイトルがクリックされたときにクリップボードにコピーされるテキストを与える
+///
+
 Column createCatalogBlock(
     {required List<Widget> children,
     required String title,
@@ -22,6 +38,23 @@ Column createCatalogBlock(
     ],
   );
 }
+
+/// ### 概要
+///
+/// - 引数で与えられた色情報を元に色を円形に表示する
+///
+/// ### 目的
+///
+/// - デザイン一覧画面で色を簡単に表示するために作成
+///
+/// ### 利用例
+///
+/// - デザイン一覧画面
+///
+/// ### 備考
+///
+/// - 引数のpropsには、色がクリックされたときにクリップボードにコピーしたいテキストを与える
+///
 
 Column createColorBlock(
     {required String title,

--- a/flutter_main/lib/views/4_component/encircled_number.dart
+++ b/flutter_main/lib/views/4_component/encircled_number.dart
@@ -1,7 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_main/views/3_template/custum_colors.dart';
 
-// 丸数字(①、②...)を表示するコンポーネント
+/// ### 概要
+///
+/// - 丸数字(①、②...)を表示するコンポーネント
+///
+/// ### 目的
+///
+/// - 丸数字は文字だけだと50までしか表示できないので作成
+///
+/// ### 使用例
+///
+/// - ステッパーコンポーネント
+///
 Container createEncircledNumber({required String num}) {
   return Container(
     alignment: Alignment.center,

--- a/flutter_main/lib/views/4_component/encircled_number.dart
+++ b/flutter_main/lib/views/4_component/encircled_number.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_main/views/3_template/custum_colors.dart';
+
+Container createEncircledNumber({required String num}) {
+  return Container(
+    alignment: Alignment.center,
+    width: 24,
+    height: 24,
+    // padding: const EdgeInsets.all(6),
+    child: SizedBox(
+      child: Text(
+        num,
+        style: const TextStyle(
+            color: CustumColors.grayLight, fontWeight: FontWeight.bold),
+      ),
+    ),
+    decoration: BoxDecoration(
+      color: CustumColors.grayBg,
+      borderRadius: BorderRadius.circular(30),
+    ),
+  );
+}

--- a/flutter_main/lib/views/4_component/encircled_number.dart
+++ b/flutter_main/lib/views/4_component/encircled_number.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_main/views/3_template/custum_colors.dart';
 
+// 丸数字(①、②...)を表示するコンポーネント
 Container createEncircledNumber({required String num}) {
   return Container(
     alignment: Alignment.center,
     width: 24,
     height: 24,
-    // padding: const EdgeInsets.all(6),
     child: SizedBox(
       child: Text(
         num,

--- a/flutter_main/lib/views/4_component/stepper_indicator_vertical.dart
+++ b/flutter_main/lib/views/4_component/stepper_indicator_vertical.dart
@@ -2,8 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_main/views/4_component/encircled_number.dart';
 import 'package:flutter_main/views/3_template/custum_colors.dart';
 
-// ステッパーのアクションボタンをなくしたもの
-// https://api.flutter.dev/flutter/material/Stepper-class.html
+/// ### 概要
+///
+/// - 進捗状況をステップ数として表示できるようにした
+/// - [stepper](https://api.flutter.dev/flutter/material/Stepper-class.html)からContinue,Cancelボタンをなくした
+///
+/// ### 目的
+/// - ステップ数表示と、次ステップに進む表示と操作を分離したいので作成
+///
+/// ### 使用例
+///
+/// - 導入前確認画面_共用玄関
+
 List<Column> createStepperIndicatorVertical({required List<Widget> children}) {
   return children
       .asMap()

--- a/flutter_main/lib/views/4_component/stepper_indicator_vertical.dart
+++ b/flutter_main/lib/views/4_component/stepper_indicator_vertical.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_main/views/4_component/encircled_number.dart';
+import 'package:flutter_main/views/3_template/custum_colors.dart';
+
+List<Column> createStepperIndicatorVertical({required List<Widget> children}) {
+  return children
+      .asMap()
+      .entries
+      .map((e) => (Column(
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Column(children: [
+                    createEncircledNumber(num: (e.key + 1).toString()),
+                    SizedBox(
+                      child: (Visibility(
+                          visible: (children.length != e.key + 1),
+                          child: const VerticalDivider(
+                              width: 20,
+                              thickness: 1,
+                              indent: 2,
+                              endIndent: 6,
+                              color: CustumColors.gray))),
+                      width: 30,
+                      height: 30,
+                    )
+                  ]),
+                  Container(
+                      margin: const EdgeInsets.only(left: 16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [e.value],
+                      )),
+                ],
+              ),
+            ],
+          )))
+      .toList();
+}

--- a/flutter_main/lib/views/4_component/stepper_indicator_vertical.dart
+++ b/flutter_main/lib/views/4_component/stepper_indicator_vertical.dart
@@ -2,11 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_main/views/4_component/encircled_number.dart';
 import 'package:flutter_main/views/3_template/custum_colors.dart';
 
+// ステッパーのアクションボタンをなくしたもの
+// https://api.flutter.dev/flutter/material/Stepper-class.html
 List<Column> createStepperIndicatorVertical({required List<Widget> children}) {
   return children
       .asMap()
       .entries
       .map((e) => (Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Row(
                 crossAxisAlignment: CrossAxisAlignment.start,

--- a/flutter_main/test/integration_test/views/2_page/home_page_test.dart
+++ b/flutter_main/test/integration_test/views/2_page/home_page_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_main/views/1_root/main_root.dart';
+import 'package:flutter_main/views/2_page/home_page.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:integration_test/integration_test.dart';
+
+// flutter test -d linux test/integration_test/views/2_page/home_page_test.dart
+// flutter test test/integration_test/views/2_page/home_page_test.dart
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ホーム画面テスト', () {
+    setUp(() {});
+    testWidgets('ボタンを押したら遷移すること', (WidgetTester tester) async {
+      await tester.pumpWidget(Builder(builder: (BuildContext context) {
+        return createMaterialApp(context, const HomePage());
+      }));
+      await tester.tap(find.text('二次元バーコードを読み込む'));
+      await tester.pumpAndSettle();
+// 遷移後、ヘッダーの文字が変化することを確認
+      expect(find.text('機器の設定'), findsOneWidget);
+    });
+  });
+}

--- a/flutter_main/test/integration_test/views/2_page/home_page_test.dart
+++ b/flutter_main/test/integration_test/views/2_page/home_page_test.dart
@@ -18,7 +18,7 @@ void main() {
       }));
       await tester.tap(find.text('二次元バーコードを読み込む'));
       await tester.pumpAndSettle();
-// 遷移後、ヘッダーの文字が変化することを確認
+      // 遷移後、ヘッダーの文字が変化することを確認
       expect(find.text('機器の設定'), findsOneWidget);
     });
   });


### PR DESCRIPTION
### 目的
- 実際のフローに合わせて、画面が正常に遷移することを確認すること
- 2画面目を作成して、実際の画面追加の実装フローを確認すること

### 追加したもの

#### ページ 
- 機器設定画面

#### コンポーネント
  - 丸数字作成コンポーネント
  - ステッパーコンポーネント

#### テスト
  - ホーム画面でボタン押下時、機器設定画面に遷移することを確認するテスト
