### PR TITLE
[main] feature: 検査例外用のカスタムException追加

### DIFF
--- a/flutter_main/lib/common/exception.dart
+++ b/flutter_main/lib/common/exception.dart
@@ -1,0 +1,6 @@
+
+/// 検査例外時の独自Exception
+class ValidateException implements Exception {
+  String message;
+  ValidateException(this.message);
+}

--- a/flutter_main/lib/common/exception.dart
+++ b/flutter_main/lib/common/exception.dart
@@ -1,4 +1,3 @@
-
 /// 検査例外時の独自Exception
 class ValidateException implements Exception {
   String message;

--- a/flutter_main/lib/src/3_infrastructures/graphql/test_gql_api.dart
+++ b/flutter_main/lib/src/3_infrastructures/graphql/test_gql_api.dart
@@ -1,4 +1,5 @@
 import 'package:artemis/artemis.dart';
+import 'package:flutter_main/common/exception.dart';
 import 'package:flutter_main/src/3_infrastructures/graphql/generated/test.dart';
 
 final client = ArtemisClient('http://localhost:8040/gql/device');
@@ -10,8 +11,7 @@ Future<String> echo() async {
     final first = response.errors!.first;
     switch (first.extensions?['code']) {
       case 'BAD_USER_INPUT':
-        // TODO どこかで独自エラーを定義して使いたい
-        throw Exception(first.message +
+        throw ValidateException(first.message +
             '\n' +
             first.extensions!['exception'].toString() +
             '\n\n');

--- a/flutter_main/lib/views/3_template/wrap_template.dart
+++ b/flutter_main/lib/views/3_template/wrap_template.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter_main/common/exception.dart';
 import 'package:flutter_main/views/4_component/error_dialog_component.dart';
 
 // 紙芝居動作時に使用するユースケースのmock処理。
@@ -32,8 +33,12 @@ Future<dynamic> exec(
     // } on SocketException catch (e) {
     //   showSystemErrorDialog(ctx, e.toString());
     //   rethrow;
+  } on ValidateException catch (e, stackTrace) {
+    // システムエラーダイアログを使っているが、検査例外なので
+    showSystemErrorDialog(ctx, e.toString(), stackTrace);
+    rethrow;
   } catch (e, stackTrace) {
-    showSystemErrorDialog(ctx, e.toString() + stackTrace.toString());
+    showSystemErrorDialog(ctx, e.toString(), stackTrace);
     rethrow;
   }
 }

--- a/flutter_main/lib/views/3_template/wrap_template.dart
+++ b/flutter_main/lib/views/3_template/wrap_template.dart
@@ -34,11 +34,12 @@ Future<dynamic> exec(
     //   showSystemErrorDialog(ctx, e.toString());
     //   rethrow;
   } on ValidateException catch (e, stackTrace) {
-    // システムエラーダイアログを使っているが、検査例外なので
-    showSystemErrorDialog(ctx, e.toString(), stackTrace);
+    // 検査例外なので、検査例外用のダイアログを用意したいが、
+    // サンプルなのでシステムエラーダイアログを使っている。
+    showSystemErrorDialog(ctx, e.toString(), stackTrace.toString());
     rethrow;
   } catch (e, stackTrace) {
-    showSystemErrorDialog(ctx, e.toString(), stackTrace);
+    showSystemErrorDialog(ctx, e.toString(), stackTrace.toString());
     rethrow;
   }
 }

--- a/flutter_main/lib/views/4_component/error_dialog_component.dart
+++ b/flutter_main/lib/views/4_component/error_dialog_component.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-Future<void> showSystemErrorDialog(BuildContext ctx, String message,
+Future<void> showSystemErrorDialog(BuildContext ctx, String message, StackTrace stacktrace,
     [Function? onPressedOk]) async {
   return await showDialog<void>(
     context: ctx,

--- a/flutter_main/lib/views/4_component/error_dialog_component.dart
+++ b/flutter_main/lib/views/4_component/error_dialog_component.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-Future<void> showSystemErrorDialog(BuildContext ctx, String message, String stacktrace,
+Future<void> showSystemErrorDialog(
+    BuildContext ctx, String message, String stacktrace,
     [Function? onPressedOk]) async {
-
   // 環境変数でスタックトレースを出すかどうか？決められるようにしたい。
   final viewMessage = message + stacktrace;
 

--- a/flutter_main/lib/views/4_component/error_dialog_component.dart
+++ b/flutter_main/lib/views/4_component/error_dialog_component.dart
@@ -1,21 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-Future<void> showSystemErrorDialog(BuildContext ctx, String message, StackTrace stacktrace,
+Future<void> showSystemErrorDialog(BuildContext ctx, String message, String stacktrace,
     [Function? onPressedOk]) async {
+
+  // 環境変数でスタックトレースを出すかどうか？決められるようにしたい。
+  final viewMessage = message + stacktrace;
+
   return await showDialog<void>(
     context: ctx,
     barrierDismissible: false,
     builder: (BuildContext ctx) {
       return AlertDialog(
         title: const Text('システムエラー'),
-        content: Text(message),
+        content: Text(viewMessage),
         scrollable: true,
         actions: <Widget>[
           TextButton(
             child: const Text('コピー'),
             onPressed: () {
-              Clipboard.setData(ClipboardData(text: message)).then((_) {
+              Clipboard.setData(ClipboardData(text: viewMessage)).then((_) {
                 ScaffoldMessenger.of(ctx).showSnackBar(const SnackBar(
                     content: Text("error messeges copied to clipboard")));
               });


### PR DESCRIPTION
## 背景

httpでの例外や、GraphQLでの例外や、DBでの例外など、全てのタイプのExceptionをwrap関数側でハンドリングすると膨大になるので、大きくタイプ分けしてエラーをハンドリングしたい。

大別すると、下記のようなイメージとなる。

* 検査例外系
* 権限エラー系
* システムエラー系
