### PR TITLE
[main] fix: Androidエミュレータで起動するとenv読み込みエラーで起動しない

### DIFF
--- a/flutter_main/lib/common/my_config.dart
+++ b/flutter_main/lib/common/my_config.dart
@@ -6,8 +6,8 @@ part 'my_config.g.dart';
 
 /// インテグレーションテスト実行時に、flutterがアセットloadを
 /// 出来なくするので、回避策としてテストでは下記から読み込むこととする。
+/// 下記のユニットテスト系セットアップだと動いた。
 /// ```dart
-/// // 下記のテストセットアップなら出来るがインテグレーションテストだと動かない。
 /// TestWidgetsFlutterBinding.ensureInitialized();
 /// ```
 /// 別件だが下記の書き方だと、通常時にもメモリに読み込まれてしまうので、
@@ -45,7 +45,7 @@ Future<MyConfig> setupMyConfig({bool isTest = false}) async {
     // テスト実行時には
     dotenv.testLoad(fileInput: testEnv);
   } else {
-    dotenv.load(fileName: 'assets/.env');
+    await dotenv.load(fileName: 'assets/.env');
   }
   final Map<String, String> map = dotenv.env;
 

--- a/flutter_main/lib/common/my_config.dart
+++ b/flutter_main/lib/common/my_config.dart
@@ -6,7 +6,7 @@ part 'my_config.g.dart';
 
 /// インテグレーションテスト実行時に、flutterがアセットloadを
 /// 出来なくするので、回避策としてテストでは下記から読み込むこととする。
-/// 下記のユニットテスト系セットアップだと動いた。
+/// （下記のユニットテスト系セットアップだと動いたが。。。）
 /// ```dart
 /// TestWidgetsFlutterBinding.ensureInitialized();
 /// ```

--- a/flutter_main/lib/common/my_config.dart
+++ b/flutter_main/lib/common/my_config.dart
@@ -39,8 +39,7 @@ class MyConfig {
 }
 
 /// 環境変数をコンフィグファイルに入れる
-Future<MyConfig> setupMyConfig({bool isTest=false}) async {
-
+Future<MyConfig> setupMyConfig({bool isTest = false}) async {
   // assetsに置いてある.env情報をloadする。
   if (isTest) {
     // テスト実行時には

--- a/flutter_main/lib/common/my_config.dart
+++ b/flutter_main/lib/common/my_config.dart
@@ -41,8 +41,8 @@ class MyConfig {
 /// 環境変数をコンフィグファイルに入れる
 Future<MyConfig> setupMyConfig({bool isTest = false}) async {
   // assetsに置いてある.env情報をloadする。
+  // テスト実行時は、ファイルからloadできないので読み込みを分ける。
   if (isTest) {
-    // テスト実行時には
     dotenv.testLoad(fileInput: testEnv);
   } else {
     await dotenv.load(fileName: 'assets/.env');

--- a/flutter_main/lib/views/1_root/main_root.dart
+++ b/flutter_main/lib/views/1_root/main_root.dart
@@ -25,7 +25,8 @@ class TestAssetBundle extends CachingAssetBundle {
   @override
   Future<ByteData> load(String key) async {
     if (key == 'resources/test') {
-      return ByteData.view(Uint8List.fromList(utf8.encode('Hello World!')).buffer);
+      return ByteData.view(
+          Uint8List.fromList(utf8.encode('Hello World!')).buffer);
     }
     return ByteData(0);
   }
@@ -33,9 +34,6 @@ class TestAssetBundle extends CachingAssetBundle {
 
 // テスト側でもMaterialAppを作成したいので、メソッド分割している
 MaterialApp createMaterialApp(BuildContext context, Widget homeWidget) {
-
-
-
   return MaterialApp(
     title: 'Flutter Demo',
     theme: ThemeData(

--- a/flutter_main/lib/views/1_root/main_root.dart
+++ b/flutter_main/lib/views/1_root/main_root.dart
@@ -1,4 +1,8 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_main/views/2_page/aa_page.dart';
 import 'package:flutter_main/views/2_page/main_page.dart';
 import 'package:flutter_main/views/2_page/bb_page.dart';
@@ -17,8 +21,21 @@ class MainRoot extends StatelessWidget {
   }
 }
 
+class TestAssetBundle extends CachingAssetBundle {
+  @override
+  Future<ByteData> load(String key) async {
+    if (key == 'resources/test') {
+      return ByteData.view(Uint8List.fromList(utf8.encode('Hello World!')).buffer);
+    }
+    return ByteData(0);
+  }
+}
+
 // テスト側でもMaterialAppを作成したいので、メソッド分割している
 MaterialApp createMaterialApp(BuildContext context, Widget homeWidget) {
+
+
+
   return MaterialApp(
     title: 'Flutter Demo',
     theme: ThemeData(

--- a/flutter_main/lib/views/1_root/main_root.dart
+++ b/flutter_main/lib/views/1_root/main_root.dart
@@ -1,8 +1,4 @@
-import 'dart:convert';
-import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_main/views/2_page/aa_page.dart';
 import 'package:flutter_main/views/2_page/main_page.dart';
 import 'package:flutter_main/views/2_page/bb_page.dart';
@@ -18,17 +14,6 @@ class MainRoot extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return createMaterialApp(context, const MainPage());
-  }
-}
-
-class TestAssetBundle extends CachingAssetBundle {
-  @override
-  Future<ByteData> load(String key) async {
-    if (key == 'resources/test') {
-      return ByteData.view(
-          Uint8List.fromList(utf8.encode('Hello World!')).buffer);
-    }
-    return ByteData(0);
   }
 }
 

--- a/flutter_main/test/integration_test/views/2_page/user_page_test.dart
+++ b/flutter_main/test/integration_test/views/2_page/user_page_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:flutter_main/src/3_infrastructures/flutter/story/usecase_mock.dart'
     as usecase_mock;
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 // flutter test -d linux test/integration_test/views/2_page/user_page_test.dart
 
@@ -30,12 +29,6 @@ void main() async {
         return createMaterialApp(context, const UserPage());
       }));
 
-
-      print('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  c');
-      await dotenv.load(fileName: "assets/.env");
-      print('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  e');
-      print(dotenv.toString());
-      
       expect(find.text(''), findsOneWidget);
       expect(find.text('Mock文字列!!'), findsNothing);
     });

--- a/flutter_main/test/integration_test/views/2_page/user_page_test.dart
+++ b/flutter_main/test/integration_test/views/2_page/user_page_test.dart
@@ -6,12 +6,13 @@ import 'package:flutter/material.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:flutter_main/src/3_infrastructures/flutter/story/usecase_mock.dart'
     as usecase_mock;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 // flutter test -d linux test/integration_test/views/2_page/user_page_test.dart
 
 void main() async {
   // 環境変数のセットアップをする（テスト用の共通処理に移動しても良いかも）
-  await setupMyConfig();
+  await setupMyConfig(isTest: true);
 
   // インテグレーションテスト（http通信ありのテスト）をする場合に必要。
   // 下記が無い状態のwidgetテストだと、http通信が全てstatus=400の空文字にモック化されてしまう。
@@ -29,6 +30,12 @@ void main() async {
         return createMaterialApp(context, const UserPage());
       }));
 
+
+      print('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  c');
+      await dotenv.load(fileName: "assets/.env");
+      print('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  e');
+      print(dotenv.toString());
+      
       expect(find.text(''), findsOneWidget);
       expect(find.text('Mock文字列!!'), findsNothing);
     });


### PR DESCRIPTION
## 原因

前回の修正で、アセットバンドルからのloadを、Fileからのloadに切り替えたが、Androidエミュレータでは.envの読み込みが出来ず、エラーとなったため起動しなくなった。

## 方針

* flutterの余計なお世話により、通常動作時とインテグレーションテスト時で.envのパース処理を同様に動かすことは出来ないと判断した。
* スクショなどを撮りたいため、インテグレーションテストでの実行はほしい。

## 修正

* テスト時は.envの内容をコード上に書く（本体の.envをコピペで貼り付け出来る記述とした。）
* コード上の値を読み込んで実行する。
